### PR TITLE
Build and test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+dist: trusty
+sudo: required
+install: true
+script:
+  - ./autogen.sh
+  - mkdir tmp
+  - cd tmp
+  - ../configure
+  - make base-kl
+  - cd ../run/dfkfb
+  - ../../tmp/bld-kl/kn10-kl dfkfb.ini

--- a/run/dfkfb/dfkfb.ini
+++ b/run/dfkfb/dfkfb.ini
@@ -15,5 +15,4 @@ set sw=400100,,0
 go
 
 ; Quit when done
-quit
-
+really-quit

--- a/src/klh10.c
+++ b/src/klh10.c
@@ -239,6 +239,8 @@ CMDDEF(cd_help,  fc_help,   CMRF_TOKS,	NULL,
 				"Basic help", "")
 CMDDEF(cd_quit,  fc_quit,   CMRF_NOARG,	NULL,
 				"Quit emulator", "")
+CMDDEF(cd_rquit, fc_rquit,  CMRF_NOARG,	NULL,
+				"Really quit!", "")
 CMDDEF(cd_load,  fc_load,   CMRF_TOKS,	"<file>",
 				"Load binary into KN10", "")
 CMDDEF(cd_dump,  fc_dump,   CMRF_TOKS,	"<file>",
@@ -330,6 +332,7 @@ KEYSBEGIN(fectbkeys)
     KEYDEF("help",	cd_help)
     KEYDEF("exit",	cd_quit)
     KEYDEF("quit",	cd_quit)
+    KEYDEF("really-quit",	cd_rquit)
     KEYDEF("load",	cd_load)
     KEYDEF("dump",	cd_dump)
     KEYDEF("go",	cd_go)
@@ -604,6 +607,14 @@ fc_quit(struct cmd_s *cm)
     mem_term();		/* Flush memory in case shared */
 
     printf("Bye!\n");
+    os_exit(0);
+}
+
+void
+fc_rquit(struct cmd_s *cm)
+{
+    dev_term();
+    mem_term();
     os_exit(0);
 }
 


### PR DESCRIPTION
This adds a .travis.yml file to control an automatic build on each commit.  I also added a small test which runs the DFKFB diagnostics.

To make this work, it seemed I had to add a console command to really quit without asking for confirmation.  When I just used `quit`, the KLH10 was still hung waiting for input.