### PR TITLE
Chaosnet fails if any chip fails

### DIFF
--- a/src/dpchudp.h
+++ b/src/dpchudp.h
@@ -44,6 +44,7 @@
 struct dpchudp_chip {
     unsigned int dpchudp_chip_chaddr; /* Chaos address */
     struct in_addr dpchudp_chip_ipaddr; /* IP address */
+    struct in_addr dpchudp_chip_new_ipaddr;
   in_port_t dpchudp_chip_ipport;	/* IP port */
   time_t dpchudp_chip_lastrcvd;	/* When last received, if dynamically added */
   char dpchudp_chip_hostname[DPCHUDP_CHIP_HOSTNAME_MAX+1];

--- a/src/dpchudp.h
+++ b/src/dpchudp.h
@@ -31,6 +31,9 @@
 #ifndef DPCHUDP_CHIP_MAX
 # define DPCHUDP_CHIP_MAX 20
 #endif
+#ifndef DPCHUDP_CHIP_HOSTNAME_MAX
+# define DPCHUDP_CHIP_HOSTNAME_MAX 100
+#endif
 
 /* If a dynamically added CHIP entry is older than this (seconds), it can get updated */
 #ifndef DPCHUDP_CHIP_DYNAMIC_AGE_LIMIT
@@ -43,6 +46,7 @@ struct dpchudp_chip {
     struct in_addr dpchudp_chip_ipaddr; /* IP address */
   in_port_t dpchudp_chip_ipport;	/* IP port */
   time_t dpchudp_chip_lastrcvd;	/* When last received, if dynamically added */
+  char dpchudp_chip_hostname[DPCHUDP_CHIP_HOSTNAME_MAX+1];
 };
 
 /* DPCHUDP-specific stuff */

--- a/src/dpchudp.h
+++ b/src/dpchudp.h
@@ -29,7 +29,7 @@
 #define DPCHUDP_VERSION ((1<<10) | (0<<5) | (0))	/* 1.0.0 */
 
 #ifndef DPCHUDP_CHIP_MAX
-# define DPCHUDP_CHIP_MAX 10
+# define DPCHUDP_CHIP_MAX 20
 #endif
 
 /* If a dynamically added CHIP entry is older than this (seconds), it can get updated */

--- a/src/dvch11.c
+++ b/src/dvch11.c
@@ -73,7 +73,7 @@ static int decosfcclossage;
 #endif
 
 #ifndef CH11_CHIP_MAX
-# define CH11_CHIP_MAX 10	/* max Chaos/IP mappings - see DPCHUDP_CHIP_MAX */
+# define CH11_CHIP_MAX 20	/* max Chaos/IP mappings - see DPCHUDP_CHIP_MAX */
 #endif
 
 #if CH11_CHIP_MAX > DPCHUDP_CHIP_MAX


### PR DESCRIPTION
If you configure ch11 with a number of Chaos-IP mappings, and one of those mappings fails because e.g. looking up a hostname doesn't work, the whole ch11 will stop working.

    KLH10# devdef chaos ub3  ch11  addr=764140 br=6 vec=270 myaddr=3150 chip=3143/up.foo.se chip=7100/sj.bar.net
    CH11 param "chip": bad value syntax: "7100/sj.bar.net"
    Device init failed

The result is that there is BUGHLT when ITS boots:

    CHAOSNET INTERFACE NOT RESPONDING (CHECK THE BREAKER ON THE UNIBUS)  
    BUGHALT.  FIND A WIZARD OR CONSIDER TAKING A CRASH DUMP.
    THE SYSTEM HAS CRASHED AND CANNOT BE REVIVED WITHOUT EXPERT ATTENTION.
    IF YOU CAN'T FIND HELP, RELOAD THE SYSTEM.
    YOU ARE NOW IN DDT.
    BUGPC/   CAI QSETUP+14   $Q-2/   CAIA 0   

I propose that it would be better to have ch11 complain loudly and then just ignore the failed mapping.

CC @bictorv