### PR TITLE
cenv.h must be the first include file

### DIFF
--- a/src/feload.c
+++ b/src/feload.c
@@ -25,6 +25,8 @@
 /*	Loads executables into physical memory.
 */
 
+#include "cenv.h"
+
 #include <stdio.h>
 #include <stdlib.h>	/* Malloc and friends */
 #include <string.h>


### PR DESCRIPTION
System include files for Debian-based ARM (and maybe others) distributions can change the definition of "off_t" from "long" to "long long" depending on the definition of _FILE_OFFSET_BITS. This needs to be consistent across all source modules. Fix feload.c by making cenv.h the first include file so that _FILE_OFFSET_BITS is defined early on.
