### PR TITLE
Add missing fclose after tape format detection.

### DIFF
--- a/src/vmtape.c
+++ b/src/vmtape.c
@@ -886,6 +886,8 @@ vmt_rdmount(register struct vmtape *t,
 	    return FALSE;
 	}
 	dfn = ta->vmta_path;
+	fclose(df);
+	df = NULL;
     }
  havefmt:
     if (vmtfmttab[fmt].tf_flags & (VMTFF_CTL | VMTFF_XCTL)) {


### PR DESCRIPTION
Without this, doing something like:

```
devmount mta0 /tmp/foo
devunmount mta0
```

(i.e. without specifying `fmt=bar` to the devmount) will leak a FILE * and file descriptor. It looks like df isn't used after this point in the function, aside from the error cleanup code at the bottom...