### PR TITLE
Add support for USB Panda Display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 dist: trusty
 sudo: required
-install: true
+install: sudo apt-get install libusb-1.0-0-dev
 script:
   - ./autogen.sh
   - mkdir tmp

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -54,7 +54,7 @@ CFLAGS_LINT ?=
 LINKER ?= $(CC)
 LDFLAGS ?=
 LDOUTF ?= -o
-LIBS ?=
+LIBS := -lusb-1.0
 NETLIBS ?= -lpcap
 
 # Variables specific to this makefile setup
@@ -193,7 +193,7 @@ OFILES_KS = klh10.o prmstr.o fecmd.o feload.o wfio.o osdsup.o \
 	vmtape.o dvtm03.o	\
 	dvlhdh.o dvdz11.o dvch11.o \
 	dpsup.o \
-	dvhost.o #dvlites.o is NOT needed for the KS-10
+	dvhost.o dvlites.o
 
 # Device Processes (DPs) built concurrently with KN10
 

--- a/src/klh10.c
+++ b/src/klh10.c
@@ -247,7 +247,7 @@ CMDDEF(cd_devwait,fc_devwait,   CMRF_TLIN,
 			"[<devid>] [<secs>]",
 			"Wait for device (or all devs)", "")
 #if KLH10_DEV_LITES
-CMDDEF(cd_lights,  fc_lights,   CMRF_TLIN,	"<hexaddr>",
+CMDDEF(cd_lights,  fc_lights,   CMRF_TLIN,	"<hexaddr>|usb",
 				"Set console lights I/O base address", "")
 #endif
 
@@ -2745,6 +2745,12 @@ fc_lights(struct cmd_s *cm)
     char *sloc = cm->cmd_arglin;
 
     if (sloc && *sloc) {
+        if (strcasecmp(sloc, "usb") == 0) {
+	    if (!lites_init(0))
+		printf("?Can't init lights -- probably not root\n");
+	    return;
+	}
+
         while(isxdigit(c = *sloc++)) {
 	    port *= 16;
 	    port += c - (isdigit(c) ? '0' : (islower(c) ? 'a' : 'A'));

--- a/src/opcods.h
+++ b/src/opcods.h
@@ -626,7 +626,7 @@ iodef(IOINOP(0700, 07), NULL,    IO_SO_APR, io_so_apr, IF_IO)	/* SO APR, */
   iodef(IOINOP(0700, 012),"SBDIAG",IO_SBDIAG,io_sbdiag,IF_IO)	/* BO PI, */
 #endif
 	 /* DATAO PI, - (KA/KI: Disp data on console lites) */
-iodef(IOINOP(0700, 013), NULL, IO_DO_PI, io_do_pi, IF_IO)	/* DO PI, */
+iodef(IOINOP(0700, 013), "WRLI", IO_DO_PI, io_do_pi, IF_IO)	/* DO PI, */
 iodef(IOINOP(0700, 014), "WRPI", IO_WRPI, io_wrpi, IF_IO)	/* CO PI, */
 iodef(IOINOP(0700, 015), "RDPI", IO_RDPI, io_rdpi, IF_IO)	/* CI PI, */
 iodef(IOINOP(0700, 016), NULL, IO_SZ_PI, io_sz_pi, IF_IO)	/* SZ PI, */


### PR DESCRIPTION
Since most people have machines with internal USB ports now, I created a USB-based Panda Display (see https://github.com/DavidGriffith/panda-display) in imitation of the old parallel-port Panda Display from Spare Time Gizmos (see http://sparetimegizmos.com/Hardware/Panda.htm).  I made three boards, built two of them, and sold the third.  It works as far as directly manipulating it with a Linux test program.  I cannot get Mark Crispin's pdp10 program for exercising the Panda Display to compile.  The machine-monitoring functionality I added to my fork of klh10 doesn't seem to use the display correctly.

I will start adding to this repo my changes and then delete my klh10 repo.