### PR TITLE
Make lights work on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  ARCH: amd64
+
+task:
+  freebsd_instance:
+    image: freebsd-12-0-release-amd64
+  install_script:
+    - pkg upgrade -y
+    - pkg install -y gmake pkgconf autotools
+  script:
+    - ./autogen.sh
+    - mkdir tmp
+    - cd tmp
+    - ../configure --enable-lights
+    - gmake -C bld-ks-its

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /configure
+/aclocal.m4
 bld/*/*.h
 bld/*/*.o
 bld/*/dpimp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 dist: trusty
 sudo: required
-install: sudo apt-get install libusb-1.0-0-dev
+install: sudo apt-get install libusb-1.0-0-dev pkg-config
 script:
   - ./autogen.sh
   - mkdir tmp

--- a/autogen.sh
+++ b/autogen.sh
@@ -19,6 +19,7 @@ builddir=$(pwd)
 cd "$srcdir"
 srcdir=$(pwd)
 
+aclocal         # creates aclocal.m4 from configure.ac
 autoconf	# creates configure from configure.ac
 autoheader	# creates src/config.h.in from configure.ac
 

--- a/configure.ac
+++ b/configure.ac
@@ -103,15 +103,10 @@ AC_CHECK_FUNC([nanosleep],
 case "${need_libusb}" in
     yes)
         # Check if libusb-1.0 is present, otherwise fail.
-        # CPULIBS is for libraries only needed by the CPU, not by other programs.
-        SAVE_LIBS="$LIBS"
-        LIBS=""
-        AC_CHECK_LIB([usb-1.0], [libusb_get_device_descriptor],
-                     [],
-                     [AC_MSG_ERROR([Lights require libusb-1.0, which I could not find.])]
-                    )
-        CPULIBS="$LIBS"
-        LIBS="$SAVE_LIBS"
+        PKG_CHECK_MODULES([libusb], [libusb-1.0],
+                          [AC_DEFINE([HAVE_LIBUSB_1_0], [1],
+                                     [Define if you have libusb-1.0.])],
+                          [AC_MSG_ERROR([Lights require libusb-1.0, which I could not find.])])
         ;;
 esac
 
@@ -287,6 +282,8 @@ AC_SUBST([CPULIBS])
 AC_SUBST([NETLIBS])
 AC_SUBST([MAKEFILE], [Makefile])
 AC_SUBST([CENVFLAGS])
+AC_SUBST([libusb_CFLAGS])
+AC_SUBST([libusb_LIBS])
 
 # -------------------------------------------------------------------------
 # Output section. State which files are going to be constructed.

--- a/mk/top.mk
+++ b/mk/top.mk
@@ -18,14 +18,14 @@
 SRC = @top_srcdir@/src
 BLDSRC = @top_builddir@/src
 CC = @CC@
-CFLAGS = -c @CFLAGS@
+CFLAGS = -c @CFLAGS@ @libusb_CFLAGS@
 CPPFLAGS = @CPPFLAGS@ -I$(BLDSRC) -I$(SRC)
 CFLAGS_LINT = -ansi -pedantic -Wall -Wshadow \
                 -Wstrict-prototypes -Wmissing-prototypes \
                 -Wmissing-declarations -Wredundant-decls
 LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
-CPULIBS = @CPULIBS@
+CPULIBS = @CPULIBS@ @libusb_LIBS@
 NETLIBS = @NETLIBS@
 
 prefix = @prefix@

--- a/src/dvlites.c
+++ b/src/dvlites.c
@@ -34,7 +34,7 @@ static int decosfcclossage;
 #if KLH10_DEV_LITES		/* Moby conditional for entire file */
 
 #if HAVE_LIBUSB_1_0
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #endif
 /*
  * For now, assume that having <sys/io.h> is equivalent to having


### PR DESCRIPTION
Hello,

I'd like or a way to enable lights if libusb is found, but discard the option if the library is not found.  This is primarily to make it easier to build for continuous configuration.

Maybe `--enable-lights=optional`?