### PR TITLE
Upgrade Cirrus CI build to FreeBSD 12.1.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ env:
 
 task:
   freebsd_instance:
-    image: freebsd-12-0-release-amd64
+    image: freebsd-12-1-release-amd64
   install_script:
     - pkg upgrade -y
     - pkg install -y gmake pkgconf autotools


### PR DESCRIPTION
I believe this will fix the Cirrus CI build failure:

```
pkg upgrade -y
Updating FreeBSD repository catalogue...
Fetching meta.txz: . done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
repository FreeBSD has no meta file, using default settings
Fetching packagesite.txz: .......... done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
pkg: Repository FreeBSD load error: meta cannot be loaded No error: 0
Unable to open created repository FreeBSD
Unable to update repository FreeBSD
Error updating repositories!
Exit status: 3