### PR TITLE
CH11: fix long-standing data corruption bug

### DIFF
--- a/src/dvch11.c
+++ b/src/dvch11.c
@@ -622,7 +622,7 @@ ch11_cmd_status(struct ch11 *ch, FILE *of)
   fprintf(of,"Input possible: %d, Output possible: %d\n", ch->ch_inactf, ch->ch_outactf);
   fprintf(of, "DP status: %d\n", ch->ch_dpstate);
   fprintf(of, "DP Rtest: %d, Stest: %d\n",
-	  (int)dp_xrtest(dp_dpxfr(&ch->ch_dp)), (int)dp_xstest(dp_dpxfr(&ch->ch_dp)));
+	  (int)dp_xrtest(dp_dpxfr(&ch->ch_dp)), (int)dp_xstest(dp_dpxto(&ch->ch_dp)));
   fprintf(of, "DP rcmd: %d, rcnt: %d\n",
 	  (int)dp_xrcmd(dp_dpxfr(&ch->ch_dp)), (int)dp_xrcnt(dp_dpxfr(&ch->ch_dp)));
   fprintf(of,"Input buffer: ");
@@ -961,7 +961,7 @@ ch11_write(struct device *d, uint18 addr, register dvureg_t val)
     /* AIM628: when both xDN and xEN are set, the computer is interrupted */
     if ((val & CH_TEN) && (val & CH_REN)) {
       /* try to be clever */
-      if (dp_xstest(dp_dpxfr(&ch->ch_dp))) {
+      if (dp_xstest(dp_dpxto(&ch->ch_dp))) {
 	ch_ogo(ch);		/* sender's turn, process output first */
 	ch_igo(ch);
       } else {

--- a/src/dvch11.c
+++ b/src/dvch11.c
@@ -838,6 +838,8 @@ ch11_read(struct device *d, register uint18 addr)
 	  fprintf(DVDBF(ch), "[CH11 reading last word, clearing RDN]\r\n");
 	ch->ch_rcnt = -1;	/* read last word */
 	REG(ch) &= ~CH_RDN;	/* Done receiving? */
+	ch->ch_inactf = TRUE;	/* OK to read another */
+	dp_xrdone(dp_dpxfr(&ch->ch_dp)); /* Done, can now ACK */
       }
       break;
     }
@@ -1548,8 +1550,6 @@ chaos_inxfer(register struct ch11 *ch)
       }
       REG(ch) |= CH_RDN;		/* Note it's done! */
     }
-    ch->ch_inactf = TRUE;	/* OK to read another */
-    dp_xrdone(dpx);		/* Done, can now ACK */
 }
 
 #endif /* KLH10_DEV_CH11 */

--- a/src/dvch11.txt
+++ b/src/dvch11.txt
@@ -7,10 +7,11 @@
 The ch11 device in KLH10 for ITS, which was originally just a dummy
 inteface to keep ITS running, is now a functional Unibus Chaosnet
 device, which supports Chaosnet-on-Ethernet and Chaosnet-over-UDP.  
-It does not support SPY (promiscuous) mode, LUP (loopback), or
-broadcast, but ITS doesn't seem to use/need these.
+It does not support SPY (promiscuous) mode, or LUP (loopback), but ITS
+doesn't seem to use/need these. It only supports broadcast on
+Ethernet, not on UDP. 
 
-Latest update: 2018-04-15
+Latest update: 2021-02-23
 
 Like other KLH10 network devices, ch11 works together with a Device
 Process which communicates with the device and reads/writes network
@@ -59,7 +60,7 @@ For "chudp":
 	used, the first IPv4 address returned is used. (Rather than
 	listing all your friends' ITS hosts directly, I suggest joining the
 	Global Chaosnet and just list its central router. See
-	https://aosnet.ch.)
+	https://chaosnet.net.)
 
 If chudpport or chip parameters are given, the ifmeth defaults to chudp.
 
@@ -88,11 +89,11 @@ to
 IFN CHAOSP,DEFOPT NM%CHA==<IPADDR 255,255,0,0>	; Set default netmask for it
 but the real fix would be to the IPMASK macro.
 
-Ideas for future work:
-- Implement Chaos-over-DTLS to get some security, on this modern Internet.
+----------------
 
-More info:
-- see https://chaosnet.net
+See https://chaosnet.net for much much more information, and
+https://github.com/bictorv/chaosnet-bridge for a bridging/routing
+program for Chaosnet.
 
 Cheers,
 


### PR DESCRIPTION
Instead of accepting new input packets after checking that the input packet is shaped OK, do it after actually reading the packet to ITS. Otherwise read packets can be overwritten while only partially read to ITS, leading to corruption of data.

This happened much more often on Eric's virtualized systems than on my Raspi-3-based one, and much more rarely on UP which runs on an old Raspi B. But now there will be order in Chaos.