### PR TITLE
Make the IMP respond to NOP pkts with IP info 

### DIFF
--- a/src/dpimp.h
+++ b/src/dpimp.h
@@ -93,7 +93,7 @@
 
 /* Version of DPIMP-specific shared memory structure */
 
-#define DPIMP_VERSION ((1<<10) | (1<<5) | (3))	/* 1.1.3 */
+#define DPIMP_VERSION ((1<<10) | (1<<5) | (4))	/* 1.1.3 */
 
 #define IFNAM_LEN	16	/* at least IFNAMSIZ! */
 

--- a/src/dpimp.h
+++ b/src/dpimp.h
@@ -93,7 +93,7 @@
 
 /* Version of DPIMP-specific shared memory structure */
 
-#define DPIMP_VERSION ((1<<10) | (1<<5) | (4))	/* 1.1.3 */
+#define DPIMP_VERSION ((1<<10) | (1<<5) | (4))	/* 1.1.4 */
 
 #define IFNAM_LEN	16	/* at least IFNAMSIZ! */
 

--- a/src/dvlhdh.c
+++ b/src/dvlhdh.c
@@ -1293,7 +1293,9 @@ imp_incheck(register struct lhdh *lh)
 	switch (dp_xrcmd(dpx)) {
 	case DPIMP_INIT:
 	    /* Do stuff to turn on IMP ready line? */
+#if 0	    // #### NOTE: let hosttoimp do this when the first NOP arrives
 	    dp_xrdone(dpx);		/* ACK it */
+#endif
 	    return 0;			/* No actual input */
 
 	case DPIMP_RPKT:		/* Input packet ready! */


### PR DESCRIPTION
This allows ITS to pick up the IP configured here, instead of having to recompile ITS to match any change. (A matching ITS patch is in a pull request for ITS.)