### PR TITLE
Always include "cenv.h" or "klh10.h" as very first.

### DIFF
--- a/src/cenv.h
+++ b/src/cenv.h
@@ -37,10 +37,9 @@
 **	CENV_SYS_x  = target OS
 **	CENV_SYSF_x = target OS features 
 **
-** Note that the CPU and SYS are expected to be explicitly specified by
-** a command line definition.  If no setting is detected this code tries
-** a few simple checks, but it is not an error if nothing is set; the
-** includer may have portable defaults.
+** Note that most of the definitions in this file are, or should be,
+** obsolete. Where still relevant, they should be detected by the
+** configure script.
 */
 
 #ifndef CENV_INCLUDED

--- a/src/dpchaos.c
+++ b/src/dpchaos.c
@@ -68,6 +68,8 @@ are completely independent.
 // Make sure short construction by | is from known network order, otherwise use casting.
 // Try to check ARP best practices (e.g retrans intervals?)
 
+#include "klh10.h"	/* Get config params */
+
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -75,8 +77,6 @@ are completely independent.
 #include <stdarg.h>
 
 #include <arpa/inet.h>
-
-#include "klh10.h"	/* Get config params */
 
 /* This must precede any other OSD includes to ensure that DECOSF gets
    the right flavor sockaddr (sigh)

--- a/src/dpimp.c
+++ b/src/dpimp.c
@@ -208,13 +208,13 @@ default for every OS that implements /dev/tun.
 
 */
 
+#include "klh10.h"	/* Get config params */
+
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdarg.h>
-
-#include "klh10.h"	/* Get config params */
 
 /* This must precede any other OSD includes to ensure that DECOSF gets
    the right flavor sockaddr (sigh)

--- a/src/dpni20.c
+++ b/src/dpni20.c
@@ -144,6 +144,8 @@ The following general situations are possible:
 			(Unsure yet if Solaris needs this)
 */
 
+#include "klh10.h"	/* For config params */
+
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
@@ -151,8 +153,6 @@ The following general situations are possible:
 #include <stdarg.h>
 #include <poll.h>	/* For NetBSD mainly */
 
-
-#include "klh10.h"	/* For config params */
 
 /* This must precede any other OSD includes to ensure that DECOSF gets
    the right flavor sockaddr (sigh)

--- a/src/dprpxx.c
+++ b/src/dprpxx.c
@@ -39,13 +39,14 @@ size, and configuration.
 
 */
 
+#include "klh10.h"	/* For config params */
+
 #include <stdio.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>	/* For malloc */
 #include <stdarg.h>
 
-#include "klh10.h"	/* For config params */
 #include "word10.h"
 #include "dpsup.h"		/* General DP defs */
 #include "dprpxx.h"		/* RPXX specific defs */

--- a/src/dptm03.c
+++ b/src/dptm03.c
@@ -207,13 +207,13 @@ So, algorithm (on DECOSF anyway) should be:
 			should remain HARDON.
 */
 
+#include "klh10.h"	/* For config params */
+
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdarg.h>
-
-#include "klh10.h"	/* For config params */
 
 #if CENV_SYS_UNIX
 # include <unistd.h>

--- a/src/dvcty.c
+++ b/src/dvcty.c
@@ -25,9 +25,10 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 
-#include "klh10.h"
 #include "kn10def.h"
 #include "kn10ops.h"
 #include "fecmd.h"

--- a/src/dvlites.c
+++ b/src/dvlites.c
@@ -20,9 +20,10 @@
 **  and is used by permission.  
 */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "klh10.h"
 
 #if !KLH10_DEV_LITES && CENV_SYS_DECOSF
 	/* Stupid gubbish needed to prevent OSF/1 AXP compiler from

--- a/src/enaddr.c
+++ b/src/enaddr.c
@@ -50,13 +50,14 @@
 				+AB:0:0:2:0:0
 */
 
+#include "cenv.h"
+
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 
-#include "cenv.h"
 #include "rcsid.h"
 #include "osdnet.h"
 

--- a/src/fecmd.c
+++ b/src/fecmd.c
@@ -25,6 +25,8 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <stdlib.h>	/* Malloc and friends */
 #include <string.h>
@@ -34,7 +36,6 @@
 #include <time.h>
 #include <stdarg.h>	/* For error-reporting functions */
 
-#include "klh10.h"
 #include "kn10mac.h"	/* FLD macros */
 #include "kn10def.h"
 #include "kn10dev.h"

--- a/src/inexts.c
+++ b/src/inexts.c
@@ -28,8 +28,8 @@
 
 /* See CODING.TXT for guidelines to coding instruction routines. */
 
-#include <stddef.h>
 #include "klh10.h"
+#include <stddef.h>
 #include "kn10def.h"	/* Machine defs */
 #include "kn10ops.h"	/* PDP-10 ops */
 

--- a/src/klh10.c
+++ b/src/klh10.c
@@ -38,6 +38,8 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <stdlib.h>	/* Malloc and friends */
 #include <string.h>
@@ -47,7 +49,6 @@
 #include <time.h>
 #include <stdarg.h>	/* For error-reporting functions */
 
-#include "klh10.h"
 #include "kn10mac.h"	/* FLD macros */
 #include "kn10def.h"
 #include "kn10dev.h"

--- a/src/kn10cpu.c
+++ b/src/kn10cpu.c
@@ -37,10 +37,11 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <setjmp.h>	/* For setjmp, longjmp */
 
-#include "klh10.h"
 #include "osdsup.h"
 #include "kn10def.h"
 #include "kn10ops.h"

--- a/src/kn10dev.c
+++ b/src/kn10dev.c
@@ -27,12 +27,13 @@
 ** definition that is used to help initialize other devices.
 */
 
+#include "klh10.h"
+
 #include <stdio.h>	/* For stderr */
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>	/* For malloc/free */
 
-#include "klh10.h"
 #include "osdsup.h"
 #include "kn10def.h"
 #include "kn10dev.h"

--- a/src/kn10pag.c
+++ b/src/kn10pag.c
@@ -25,10 +25,11 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <string.h>
 
-#include "klh10.h"
 #include "osdsup.h"
 #include "kn10def.h"
 #include "kn10ops.h"

--- a/src/opdata.c
+++ b/src/opdata.c
@@ -24,10 +24,11 @@
 
 #define EXTDEF		/* Definitions, not declarations! */
 
+#include "klh10.h"
+
 #include <stddef.h>	/* For NULL */
 #include <stdio.h>	/* For op_init error reporting */
 
-#include "klh10.h"
 #include "kn10def.h"
 #include "opdefs.h"
 

--- a/src/osdsup.c
+++ b/src/osdsup.c
@@ -43,11 +43,12 @@
  *
  */
 
+#include "klh10.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>	/* For strrchr */
 
-#include "klh10.h"
 #include "kn10def.h"
 #include "osdsup.h"
 #include "kn10ops.h"

--- a/src/prmstr.c
+++ b/src/prmstr.c
@@ -27,6 +27,8 @@
 ** hence must avoid any dependencies on other code.
 */
 
+#include "cenv.h"	/* Just in case of LFS */
+
 #include <stdio.h>
 #include <stdlib.h>	/* Malloc and friends */
 #include <string.h>

--- a/src/tapedd.c
+++ b/src/tapedd.c
@@ -46,6 +46,8 @@
 ** this; OSDTAP.C could complete it.
 */
 
+#include "cenv.h"
+
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/src/udlconv.c
+++ b/src/udlconv.c
@@ -162,6 +162,8 @@ Lisp format, the -right- thing to do is to do this all from Maclisp!
 
 */
 
+#include "cenv.h"
+
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>

--- a/src/uexbconv.c
+++ b/src/uexbconv.c
@@ -59,6 +59,8 @@ and output as bytes in the following order by the code at SAVGRC:
 <jrst>,,<saddr> => 0,,<addr> =>	<xxxx><B3><B2><B1><B0>	hi 4 bits dropped
 
 */
+#include "cenv.h"	/* Just in case of LFS */
+
 #include <stdio.h>
 
 #include "word10.h"

--- a/src/vdisk.c
+++ b/src/vdisk.c
@@ -28,13 +28,14 @@
  *
  */
 
+#include "cenv.h"
+
 #include <stdio.h>
 #include <stdlib.h>	/* For malloc */
 #include <stdarg.h>
 #include <string.h>
 
 #include "rcsid.h"
-#include "cenv.h"
 #include "word10.h"
 #include "osdsup.h"
 #include "vdisk.h"

--- a/src/vdkfmt.c
+++ b/src/vdkfmt.c
@@ -34,6 +34,8 @@
 **
 */
 
+#include "cenv.h"
+
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -44,7 +46,6 @@
 #include <sys/file.h>		/* For open() flags */
 
 #include "rcsid.h"
-#include "cenv.h"
 #include "osdsup.h"
 #include "vdisk.h"		/* Include virtual disk stuff */
 

--- a/src/vmtape.c
+++ b/src/vmtape.c
@@ -105,6 +105,8 @@ hardware devices so as to finally provide a consistent interface.
 */
 
 
+#include "klh10.h"
+
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>	/* For malloc */
@@ -114,7 +116,6 @@ hardware devices so as to finally provide a consistent interface.
 #include <stdarg.h>	/* For error-reporting functions */
 #include <limits.h>
 
-#include "klh10.h"
 #include "osdsup.h"
 #include "word10.h"
 #include "wfio.h"	/* For word-based file i/o */

--- a/src/wfconv.c
+++ b/src/wfconv.c
@@ -40,6 +40,8 @@
 
 */
 
+#include "cenv.h"	/* Just in case of LFS */
+
 #include <stdio.h>
 #include <stdlib.h>	/* Malloc and friends */
 #include <string.h>

--- a/src/wxtest.c
+++ b/src/wxtest.c
@@ -44,6 +44,8 @@ guaranteed to be complete or reliable, and it's time-consuming to do
 this for all possible variations.
 */
 
+#include "cenv.h"	/* Just in case of LFS */
+
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>


### PR DESCRIPTION
Always include `"cenv.h"` or `"klh10.h"` as very first.

`"klh10.h"` includes `"cenv.h"`.

This is possibly needed on systems that need some defines before including system headers, for Long File Support.

I either moved an existing include line up or added `#include "cenv.h"` where none of these was included before.

Note that most of the definitions in the `"cenv.h"` file are, or should be, obsolete. Where still relevant, they should be detected by the configure script.

Should fix #31.