### PR TITLE
Fix a NULL argument to fprintf()

### DIFF
--- a/src/prmstr.c
+++ b/src/prmstr.c
@@ -66,7 +66,7 @@ int prm_varset(char **acp,
 
     if (!(cp = strchr(cp, '='))) {
 	if (ef)
-	    fprintf(ef, "Bad syntax for \"%s\", must be <var>=<value>\n", cp);
+	    fprintf(ef, "Bad syntax for \"%s\", must be <var>=<value>\n", *acp);
 	return FALSE;
     }
 


### PR DESCRIPTION
which was detected by gcc.
cp is NULL in the call because of the if() it is inside.