### PR TITLE
Use Ubuntu 22, phase out 18.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
Use Ubuntu 22, phase out 18. The older version doesn't seem to be available for github actions any more.