### PR TITLE
Fix uninitialized pfname in pfopen(); fix "ifc=tap0" gets you tap1

### DIFF
--- a/src/osdnet.c
+++ b/src/osdnet.c
@@ -1683,6 +1683,13 @@ pfopen(char *basename, struct tuntap_context *tt_ctx, struct osnpf *osnpf)
     int fd;
     int i = 0;
 
+    if (strlen(osnpf->osnpf_ifnam) < BASENAMESIZE-1) {
+      strncpy(pfname, osnpf->osnpf_ifnam, BASENAMESIZE);
+    } else {
+      esfatal(1, "%s: ifname name %s too long for pfname size %d",
+	      __FUNCTION__, osnpf->osnpf_ifnam, BASENAMESIZE);
+    };
+    
     if (DP_DBGFLG)
 	dbprint("pfopen: ifnam=%s", osnpf->osnpf_ifnam);
 

--- a/src/osdnet.c
+++ b/src/osdnet.c
@@ -1683,13 +1683,6 @@ pfopen(char *basename, struct tuntap_context *tt_ctx, struct osnpf *osnpf)
     int fd;
     int i = 0;
 
-    if (strlen(osnpf->osnpf_ifnam) < BASENAMESIZE-1) {
-      strncpy(pfname, osnpf->osnpf_ifnam, BASENAMESIZE);
-    } else {
-      esfatal(1, "%s: ifname name %s too long for pfname size %d",
-	      __FUNCTION__, osnpf->osnpf_ifnam, BASENAMESIZE);
-    };
-    
     if (DP_DBGFLG)
 	dbprint("pfopen: ifnam=%s", osnpf->osnpf_ifnam);
 
@@ -1712,20 +1705,19 @@ pfopen(char *basename, struct tuntap_context *tt_ctx, struct osnpf *osnpf)
 	    (void) snprintf(pfname, BASENAMESIZE, "%s%d", basename, i++);
 	    fd = open(pfname, O_RDWR, 0);
 	} while (fd < 0 && errno == EBUSY);	/* If device busy, keep looking */
-    }
-
-    if (fd < 0) {
-	/* Note possible error meanings:
-	   ENOENT - no such filename
-	   ENXIO  - not configured in kernel
-	*/
-	esfatal(1, "Couldn't find or open packetfilter device, last tried %s",
-		pfname);
-    }
+	if (fd >= 0) {
+            basenamecpy(osnpf->osnpf_ifnam, pfname, IFNAM_LEN);
+	} else {	  
+  	    /* Note possible error meanings:
+	       ENOENT - no such filename
+	       ENXIO  - not configured in kernel
+	    */
+	    esfatal(1, "Couldn't find or open packetfilter device, last tried %s",
+	 	       pfname);
+	};
+    };
 
     tt_ctx->my_tap = TRUE;
-    basenamecpy(osnpf->osnpf_ifnam, pfname, IFNAM_LEN);
-
     return fd;		/* Success! */
 }
 


### PR DESCRIPTION
In pfopen(), if opening a cloning device, the _uninitialized_ value of pfname is copied into `osnpf->osnpf_ifnam` by the    `basenamecpy(osnpf->osnpf_ifnam, pfname, IFNAM_LEN);` statement, just before the return.  The result _seems_ to be that instead of opening the desired tap (e.g. tap0), the garbled value of `osnpf->osnpf_ifnam` causes the next available tap to be opened (e.g., tap1).

This patch initializes pfname so that the correct ifname is copied.

A simple `strncpy()` might be sufficient, but since `osnpf_osnpf_ifnam` can be up to 4096 characters (in Debian) and pfname is length 32, it seemed prudent to add guardrails to avoid buffer overflow.

**On Raspberry Pi (Debian) Trixie, this patch corrects (?) the behavior that asking for tap0, for example, in the devdef statement `... ifc=tap0` gets you tap1.  That is, applying this patch _seems_ to result in initializing the ifc you requested.**  It's not clear if getting `tap<n+1>` when you request `tap<n>` was a design feature or bug, so the change of getting the tap you requested may be an unacceptable result.   Also, this patch may only impact Debian systems using the tap interface method. 

So please confirm that applying this patch results in desirable behavior on various systems before propagating in master.
